### PR TITLE
feat: 更好的单元测试，更精确的覆盖率

### DIFF
--- a/app/routes/user.py
+++ b/app/routes/user.py
@@ -8,7 +8,6 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.models.user import User
 from app.schemas.user import UserCreate, UserUpdate
 from app.services.auth import (
-    ACCESS_TOKEN_EXPIRE_MINUTES,
     Token,
     authenticate_user,
     create_access_token,
@@ -16,6 +15,7 @@ from app.services.auth import (
     get_password_hash,
 )
 from app.services.database import get_db
+from config import ACCESS_TOKEN_EXPIRE_MINUTES
 
 router = APIRouter(prefix="/api/v1/user")
 
@@ -36,34 +36,40 @@ async def register(user: UserCreate, db: AsyncSession = Depends(get_db)):
     try:
         db.add(new_user)
         await db.commit()
-        await db.refresh(new_user)
-        return new_user
     except IntegrityError as e:
         # 捕获唯一性约束错误
-        if "username" in str(e):
+        if "(username)" in str(e):
             raise HTTPException(
                 status_code=status.HTTP_400_BAD_REQUEST,
                 detail=f"{str(e.orig).split('DETAIL: ')[-1]}",
             )
-        elif "email" in str(e):
+        if "(email)" in str(e):
             raise HTTPException(
                 status_code=status.HTTP_400_BAD_REQUEST,
                 detail=f"{str(e.orig).split('DETAIL: ')[-1]}",
             )
-        else:
-            raise HTTPException(
-                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-                detail=f"An unexpected error occurred: {str(e.orig).split('DETAIL: ')[-1]}",
-            )
+    except Exception as e:
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail=f"An unexpected error occurred: {str(e)}",
+        )
+    await db.refresh(new_user)
+    return new_user
 
 
-@router.post("/login", response_model=Token)
+@router.post("/token", response_model=Token)
 async def login_for_access_token(form_data: OAuth2PasswordRequestForm = Depends(), db: AsyncSession = Depends(get_db)):
     """
     用户登录接口
     - 验证用户名和密码
     - 生成并返回 JWT 令牌
     """
+    if not (form_data.username and form_data.password):
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail="Username and password is required",
+            headers={"WWW-Authenticate": "Bearer"},
+        )
     user = await authenticate_user(db, form_data.username, form_data.password)
     if not user:
         raise HTTPException(
@@ -78,7 +84,6 @@ async def login_for_access_token(form_data: OAuth2PasswordRequestForm = Depends(
 
     # 更新用户最后登录时间和激活状态
     user.last_login = datetime.now(tz=timezone.utc)
-    user.is_active = True
     db.add(user)
     await db.commit()
 
@@ -112,19 +117,25 @@ async def update_user_me(
     if user_update.password:
         current_user.password_hash = get_password_hash(user_update.password)
 
-    db.add(current_user)
-    await db.commit()
-    await db.refresh(current_user)
+    try:
+        db.add(current_user)
+        await db.commit()
+        await db.refresh(current_user)
+    except IntegrityError as e:
+        # 捕获唯一性约束错误
+        if "(username)" in str(e):
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail=f"{str(e.orig).split('DETAIL: ')[-1]}",
+            )
+        if "(email)" in str(e):
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail=f"{str(e.orig).split('DETAIL: ')[-1]}",
+            )
+    except Exception as e:
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail=f"An unexpected error occurred: {str(e)}",
+        )
     return current_user
-
-
-@router.post("/logout")
-async def logout(db: AsyncSession = Depends(get_db), current_user: User = Depends(get_current_user)):
-    """
-    用户注销接口
-    - 将用户状态设置为未激活
-    """
-    current_user.is_active = False
-    db.add(current_user)
-    await db.commit()
-    return {"message": "Successfully logged out"}

--- a/app/schemas/user.py
+++ b/app/schemas/user.py
@@ -1,3 +1,5 @@
+from typing import Optional
+
 from pydantic import BaseModel, EmailStr, field_validator
 
 
@@ -46,6 +48,6 @@ class UserCreate(BaseModel):
 
 # 用户更新请求模型
 class UserUpdate(BaseModel):
-    username: str
-    email: str
-    password: str
+    username: Optional[str] = None
+    email: Optional[str] = None
+    password: Optional[str] = None

--- a/app/services/auth.py
+++ b/app/services/auth.py
@@ -11,10 +11,7 @@ from sqlalchemy.future import select
 
 from app.models.user import User
 from app.services.database import get_db
-
-SECRET_KEY = "your-secret-key"
-ALGORITHM = "HS256"
-ACCESS_TOKEN_EXPIRE_MINUTES = 30
+from config import ALGORITHM, SECRET_KEY
 
 pwd_context = CryptContext(schemes=["argon2"], deprecated="auto")
 
@@ -93,7 +90,7 @@ async def get_current_user(token: str = Depends(oauth2_scheme), db: AsyncSession
     user = result.scalars().first()
 
     # 检查用户是否存在或未激活
-    if user is None or not user.is_active:
+    if user is None:
         raise credentials_exception
 
     return user

--- a/config.py
+++ b/config.py
@@ -9,3 +9,7 @@ load_dotenv(env_file)
 
 DATABASE_URL = os.getenv("DATABASE_URL") or ""
 TEST_DATABASE_URL = os.getenv("TEST_DATABASE_URL") or ""
+
+SECRET_KEY = "your-secret-key"
+ALGORITHM = "HS256"
+ACCESS_TOKEN_EXPIRE_MINUTES = 30

--- a/poetry.lock
+++ b/poetry.lock
@@ -300,7 +300,7 @@ files = [
     {file = "cffi-1.17.1-cp39-cp39-win_amd64.whl", hash = "sha256:d016c76bdd850f3c626af19b0542c9677ba156e4ee4fccfdd7848803533ef662"},
     {file = "cffi-1.17.1.tar.gz", hash = "sha256:1c39c6016c32bc48dd54561950ebd6836e1670f2ae46128f67cf49e789c52824"},
 ]
-markers = {dev = "os_name == \"nt\" and implementation_name != \"pypy\""}
+markers = {dev = "os_name == \"nt\" and implementation_name != \"pypy\" or platform_python_implementation == \"CPython\" and sys_platform == \"win32\""}
 
 [package.dependencies]
 pycparser = "*"
@@ -570,13 +570,73 @@ all = ["email-validator (>=2.0.0)", "fastapi-cli[standard] (>=0.0.5)", "httpx (>
 standard = ["email-validator (>=2.0.0)", "fastapi-cli[standard] (>=0.0.5)", "httpx (>=0.23.0)", "jinja2 (>=3.1.5)", "python-multipart (>=0.0.18)", "uvicorn[standard] (>=0.12.0)"]
 
 [[package]]
+name = "gevent"
+version = "24.11.1"
+description = "Coroutine-based network library"
+optional = false
+python-versions = ">=3.9"
+groups = ["dev"]
+files = [
+    {file = "gevent-24.11.1-cp310-cp310-macosx_11_0_universal2.whl", hash = "sha256:92fe5dfee4e671c74ffaa431fd7ffd0ebb4b339363d24d0d944de532409b935e"},
+    {file = "gevent-24.11.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:b7bfcfe08d038e1fa6de458891bca65c1ada6d145474274285822896a858c870"},
+    {file = "gevent-24.11.1-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:7398c629d43b1b6fd785db8ebd46c0a353880a6fab03d1cf9b6788e7240ee32e"},
+    {file = "gevent-24.11.1-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:d7886b63ebfb865178ab28784accd32f287d5349b3ed71094c86e4d3ca738af5"},
+    {file = "gevent-24.11.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d9ca80711e6553880974898d99357fb649e062f9058418a92120ca06c18c3c59"},
+    {file = "gevent-24.11.1-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:e24181d172f50097ac8fc272c8c5b030149b630df02d1c639ee9f878a470ba2b"},
+    {file = "gevent-24.11.1-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:1d4fadc319b13ef0a3c44d2792f7918cf1bca27cacd4d41431c22e6b46668026"},
+    {file = "gevent-24.11.1-cp310-cp310-win_amd64.whl", hash = "sha256:3d882faa24f347f761f934786dde6c73aa6c9187ee710189f12dcc3a63ed4a50"},
+    {file = "gevent-24.11.1-cp311-cp311-macosx_11_0_universal2.whl", hash = "sha256:351d1c0e4ef2b618ace74c91b9b28b3eaa0dd45141878a964e03c7873af09f62"},
+    {file = "gevent-24.11.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:b5efe72e99b7243e222ba0c2c2ce9618d7d36644c166d63373af239da1036bab"},
+    {file = "gevent-24.11.1-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:9d3b249e4e1f40c598ab8393fc01ae6a3b4d51fc1adae56d9ba5b315f6b2d758"},
+    {file = "gevent-24.11.1-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:81d918e952954675f93fb39001da02113ec4d5f4921bf5a0cc29719af6824e5d"},
+    {file = "gevent-24.11.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c9c935b83d40c748b6421625465b7308d87c7b3717275acd587eef2bd1c39546"},
+    {file = "gevent-24.11.1-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:ff96c5739834c9a594db0e12bf59cb3fa0e5102fc7b893972118a3166733d61c"},
+    {file = "gevent-24.11.1-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:d6c0a065e31ef04658f799215dddae8752d636de2bed61365c358f9c91e7af61"},
+    {file = "gevent-24.11.1-cp311-cp311-win_amd64.whl", hash = "sha256:97e2f3999a5c0656f42065d02939d64fffaf55861f7d62b0107a08f52c984897"},
+    {file = "gevent-24.11.1-cp312-cp312-macosx_11_0_universal2.whl", hash = "sha256:a3d75fa387b69c751a3d7c5c3ce7092a171555126e136c1d21ecd8b50c7a6e46"},
+    {file = "gevent-24.11.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:beede1d1cff0c6fafae3ab58a0c470d7526196ef4cd6cc18e7769f207f2ea4eb"},
+    {file = "gevent-24.11.1-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:85329d556aaedced90a993226d7d1186a539c843100d393f2349b28c55131c85"},
+    {file = "gevent-24.11.1-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:816b3883fa6842c1cf9d2786722014a0fd31b6312cca1f749890b9803000bad6"},
+    {file = "gevent-24.11.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b24d800328c39456534e3bc3e1684a28747729082684634789c2f5a8febe7671"},
+    {file = "gevent-24.11.1-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:a5f1701ce0f7832f333dd2faf624484cbac99e60656bfbb72504decd42970f0f"},
+    {file = "gevent-24.11.1-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:d740206e69dfdfdcd34510c20adcb9777ce2cc18973b3441ab9767cd8948ca8a"},
+    {file = "gevent-24.11.1-cp312-cp312-win_amd64.whl", hash = "sha256:68bee86b6e1c041a187347ef84cf03a792f0b6c7238378bf6ba4118af11feaae"},
+    {file = "gevent-24.11.1-cp313-cp313-macosx_11_0_universal2.whl", hash = "sha256:d618e118fdb7af1d6c1a96597a5cd6ac84a9f3732b5be8515c6a66e098d498b6"},
+    {file = "gevent-24.11.1-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2142704c2adce9cd92f6600f371afb2860a446bfd0be5bd86cca5b3e12130766"},
+    {file = "gevent-24.11.1-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:92e0d7759de2450a501effd99374256b26359e801b2d8bf3eedd3751973e87f5"},
+    {file = "gevent-24.11.1-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:ca845138965c8c56d1550499d6b923eb1a2331acfa9e13b817ad8305dde83d11"},
+    {file = "gevent-24.11.1-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:356b73d52a227d3313f8f828025b665deada57a43d02b1cf54e5d39028dbcf8d"},
+    {file = "gevent-24.11.1-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:58851f23c4bdb70390f10fc020c973ffcf409eb1664086792c8b1e20f25eef43"},
+    {file = "gevent-24.11.1-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:1ea50009ecb7f1327347c37e9eb6561bdbc7de290769ee1404107b9a9cba7cf1"},
+    {file = "gevent-24.11.1-cp313-cp313-win_amd64.whl", hash = "sha256:ec68e270543ecd532c4c1d70fca020f90aa5486ad49c4f3b8b2e64a66f5c9274"},
+    {file = "gevent-24.11.1-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d9347690f4e53de2c4af74e62d6fabc940b6d4a6cad555b5a379f61e7d3f2a8e"},
+    {file = "gevent-24.11.1-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:8619d5c888cb7aebf9aec6703e410620ef5ad48cdc2d813dd606f8aa7ace675f"},
+    {file = "gevent-24.11.1-cp39-cp39-win32.whl", hash = "sha256:c6b775381f805ff5faf250e3a07c0819529571d19bb2a9d474bee8c3f90d66af"},
+    {file = "gevent-24.11.1-cp39-cp39-win_amd64.whl", hash = "sha256:1c3443b0ed23dcb7c36a748d42587168672953d368f2956b17fad36d43b58836"},
+    {file = "gevent-24.11.1-pp310-pypy310_pp73-macosx_11_0_universal2.whl", hash = "sha256:f43f47e702d0c8e1b8b997c00f1601486f9f976f84ab704f8f11536e3fa144c9"},
+    {file = "gevent-24.11.1.tar.gz", hash = "sha256:8bd1419114e9e4a3ed33a5bad766afff9a3cf765cb440a582a1b3a9bc80c1aca"},
+]
+
+[package.dependencies]
+cffi = {version = ">=1.17.1", markers = "platform_python_implementation == \"CPython\" and sys_platform == \"win32\""}
+greenlet = {version = ">=3.1.1", markers = "platform_python_implementation == \"CPython\""}
+"zope.event" = "*"
+"zope.interface" = "*"
+
+[package.extras]
+dnspython = ["dnspython (>=1.16.0,<2.0) ; python_version < \"3.10\"", "idna ; python_version < \"3.10\""]
+docs = ["furo", "repoze.sphinx.autointerface", "sphinx", "sphinxcontrib-programoutput", "zope.schema"]
+monitor = ["psutil (>=5.7.0) ; sys_platform != \"win32\" or platform_python_implementation == \"CPython\""]
+recommended = ["cffi (>=1.17.1) ; platform_python_implementation == \"CPython\"", "dnspython (>=1.16.0,<2.0) ; python_version < \"3.10\"", "idna ; python_version < \"3.10\"", "psutil (>=5.7.0) ; sys_platform != \"win32\" or platform_python_implementation == \"CPython\""]
+test = ["cffi (>=1.17.1) ; platform_python_implementation == \"CPython\"", "coverage (>=5.0) ; sys_platform != \"win32\"", "dnspython (>=1.16.0,<2.0) ; python_version < \"3.10\"", "idna ; python_version < \"3.10\"", "objgraph", "psutil (>=5.7.0) ; sys_platform != \"win32\" or platform_python_implementation == \"CPython\"", "requests"]
+
+[[package]]
 name = "greenlet"
 version = "3.1.1"
 description = "Lightweight in-process concurrent programming"
 optional = false
 python-versions = ">=3.7"
 groups = ["main", "dev"]
-markers = "python_version < \"3.14\" and (platform_machine == \"aarch64\" or platform_machine == \"ppc64le\" or platform_machine == \"x86_64\" or platform_machine == \"amd64\" or platform_machine == \"AMD64\" or platform_machine == \"win32\" or platform_machine == \"WIN32\")"
 files = [
     {file = "greenlet-3.1.1-cp310-cp310-macosx_11_0_universal2.whl", hash = "sha256:0bbae94a29c9e5c7e4a2b7f0aae5c17e8e90acbfd3bf6270eeba60c39fce3563"},
     {file = "greenlet-3.1.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0fde093fb93f35ca72a556cf72c92ea3ebfda3d79fc35bb19fbe685853869a83"},
@@ -652,6 +712,7 @@ files = [
     {file = "greenlet-3.1.1-cp39-cp39-win_amd64.whl", hash = "sha256:3319aa75e0e0639bc15ff54ca327e8dc7a6fe404003496e3c6925cd3142e0e22"},
     {file = "greenlet-3.1.1.tar.gz", hash = "sha256:4ce3ac6cdb6adf7946475d7ef31777c26d94bccc377e070a7986bd2d5c515467"},
 ]
+markers = {main = "python_version < \"3.14\" and (platform_machine == \"aarch64\" or platform_machine == \"ppc64le\" or platform_machine == \"x86_64\" or platform_machine == \"amd64\" or platform_machine == \"AMD64\" or platform_machine == \"win32\" or platform_machine == \"WIN32\")", dev = "python_version < \"3.14\" and (platform_machine == \"aarch64\" or platform_machine == \"ppc64le\" or platform_machine == \"x86_64\" or platform_machine == \"amd64\" or platform_machine == \"AMD64\" or platform_machine == \"win32\" or platform_machine == \"WIN32\") or platform_python_implementation == \"CPython\""}
 
 [package.extras]
 docs = ["Sphinx", "furo"]
@@ -918,7 +979,7 @@ files = [
     {file = "pycparser-2.22-py3-none-any.whl", hash = "sha256:c3702b6d3dd8c7abc1afa565d7e63d53a1d0bd86cdc24edd75470f4de499cfcc"},
     {file = "pycparser-2.22.tar.gz", hash = "sha256:491c8be9c040f5390f5bf44a5b07752bd07f56edf992381b05c701439eec10f6"},
 ]
-markers = {dev = "os_name == \"nt\" and implementation_name != \"pypy\""}
+markers = {dev = "os_name == \"nt\" and implementation_name != \"pypy\" or platform_python_implementation == \"CPython\" and sys_platform == \"win32\""}
 
 [[package]]
 name = "pydantic"
@@ -1077,6 +1138,22 @@ pluggy = ">=1.5,<2"
 dev = ["argcomplete", "attrs (>=19.2)", "hypothesis (>=3.56)", "mock", "pygments (>=2.7.2)", "requests", "setuptools", "xmlschema"]
 
 [[package]]
+name = "pytest-async-sqlalchemy"
+version = "0.2.0"
+description = "Database testing fixtures using the SQLAlchemy asyncio API"
+optional = false
+python-versions = ">=3.6"
+groups = ["dev"]
+files = [
+    {file = "pytest-async-sqlalchemy-0.2.0.tar.gz", hash = "sha256:0dcf80fdff1ea0046834cff2bc100c82d159e45a7ae21545a6ba9119a962b9d7"},
+    {file = "pytest_async_sqlalchemy-0.2.0-py3-none-any.whl", hash = "sha256:60d7159f43d21e79d7051841fd2d6e094b7267ddc8d7192daea597afca938b12"},
+]
+
+[package.dependencies]
+pytest = ">=6.0.0"
+sqlalchemy = ">=1.4.0"
+
+[[package]]
 name = "pytest-asyncio"
 version = "0.25.3"
 description = "Pytest support for asyncio"
@@ -1194,6 +1271,27 @@ files = [
 
 [package.dependencies]
 pyasn1 = ">=0.1.3"
+
+[[package]]
+name = "setuptools"
+version = "76.1.0"
+description = "Easily download, build, install, upgrade, and uninstall Python packages"
+optional = false
+python-versions = ">=3.9"
+groups = ["dev"]
+files = [
+    {file = "setuptools-76.1.0-py3-none-any.whl", hash = "sha256:34750dcb17d046929f545dec9b8349fe42bf4ba13ddffee78428aec422dbfb73"},
+    {file = "setuptools-76.1.0.tar.gz", hash = "sha256:4959b9ad482ada2ba2320c8f1a8d8481d4d8d668908a7a1b84d987375cd7f5bd"},
+]
+
+[package.extras]
+check = ["pytest-checkdocs (>=2.4)", "pytest-ruff (>=0.2.1) ; sys_platform != \"cygwin\"", "ruff (>=0.8.0) ; sys_platform != \"cygwin\""]
+core = ["importlib_metadata (>=6) ; python_version < \"3.10\"", "jaraco.collections", "jaraco.functools (>=4)", "jaraco.text (>=3.7)", "more_itertools", "more_itertools (>=8.8)", "packaging", "packaging (>=24.2)", "platformdirs (>=4.2.2)", "tomli (>=2.0.1) ; python_version < \"3.11\"", "wheel (>=0.43.0)"]
+cover = ["pytest-cov"]
+doc = ["furo", "jaraco.packaging (>=9.3)", "jaraco.tidelift (>=1.4)", "pygments-github-lexers (==0.0.5)", "pyproject-hooks (!=1.1)", "rst.linker (>=1.9)", "sphinx (>=3.5)", "sphinx-favicon", "sphinx-inline-tabs", "sphinx-lint", "sphinx-notfound-page (>=1,<2)", "sphinx-reredirects", "sphinxcontrib-towncrier", "towncrier (<24.7)"]
+enabler = ["pytest-enabler (>=2.2)"]
+test = ["build[virtualenv] (>=1.0.3)", "filelock (>=3.4.0)", "ini2toml[lite] (>=0.14)", "jaraco.develop (>=7.21) ; python_version >= \"3.9\" and sys_platform != \"cygwin\"", "jaraco.envs (>=2.2)", "jaraco.path (>=3.7.2)", "jaraco.test (>=5.5)", "packaging (>=24.2)", "pip (>=19.1)", "pyproject-hooks (!=1.1)", "pytest (>=6,!=8.1.*)", "pytest-home (>=0.5)", "pytest-perf ; sys_platform != \"cygwin\"", "pytest-subprocess", "pytest-timeout", "pytest-xdist (>=3)", "tomli-w (>=1.0.0)", "virtualenv (>=13.0.0)", "wheel (>=0.44.0)"]
+type = ["importlib_metadata (>=7.0.2) ; python_version < \"3.10\"", "jaraco.develop (>=7.21) ; sys_platform != \"cygwin\"", "mypy (==1.14.*)", "pytest-mypy"]
 
 [[package]]
 name = "six"
@@ -1396,7 +1494,81 @@ h11 = ">=0.8"
 [package.extras]
 standard = ["colorama (>=0.4) ; sys_platform == \"win32\"", "httptools (>=0.6.3)", "python-dotenv (>=0.13)", "pyyaml (>=5.1)", "uvloop (>=0.14.0,!=0.15.0,!=0.15.1) ; sys_platform != \"win32\" and sys_platform != \"cygwin\" and platform_python_implementation != \"PyPy\"", "watchfiles (>=0.13)", "websockets (>=10.4)"]
 
+[[package]]
+name = "zope-event"
+version = "5.0"
+description = "Very basic event publishing system"
+optional = false
+python-versions = ">=3.7"
+groups = ["dev"]
+files = [
+    {file = "zope.event-5.0-py3-none-any.whl", hash = "sha256:2832e95014f4db26c47a13fdaef84cef2f4df37e66b59d8f1f4a8f319a632c26"},
+    {file = "zope.event-5.0.tar.gz", hash = "sha256:bac440d8d9891b4068e2b5a2c5e2c9765a9df762944bda6955f96bb9b91e67cd"},
+]
+
+[package.dependencies]
+setuptools = "*"
+
+[package.extras]
+docs = ["Sphinx"]
+test = ["zope.testrunner"]
+
+[[package]]
+name = "zope-interface"
+version = "7.2"
+description = "Interfaces for Python"
+optional = false
+python-versions = ">=3.8"
+groups = ["dev"]
+files = [
+    {file = "zope.interface-7.2-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:ce290e62229964715f1011c3dbeab7a4a1e4971fd6f31324c4519464473ef9f2"},
+    {file = "zope.interface-7.2-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:05b910a5afe03256b58ab2ba6288960a2892dfeef01336dc4be6f1b9ed02ab0a"},
+    {file = "zope.interface-7.2-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:550f1c6588ecc368c9ce13c44a49b8d6b6f3ca7588873c679bd8fd88a1b557b6"},
+    {file = "zope.interface-7.2-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:0ef9e2f865721553c6f22a9ff97da0f0216c074bd02b25cf0d3af60ea4d6931d"},
+    {file = "zope.interface-7.2-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:27f926f0dcb058211a3bb3e0e501c69759613b17a553788b2caeb991bed3b61d"},
+    {file = "zope.interface-7.2-cp310-cp310-win_amd64.whl", hash = "sha256:144964649eba4c5e4410bb0ee290d338e78f179cdbfd15813de1a664e7649b3b"},
+    {file = "zope.interface-7.2-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:1909f52a00c8c3dcab6c4fad5d13de2285a4b3c7be063b239b8dc15ddfb73bd2"},
+    {file = "zope.interface-7.2-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:80ecf2451596f19fd607bb09953f426588fc1e79e93f5968ecf3367550396b22"},
+    {file = "zope.interface-7.2-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:033b3923b63474800b04cba480b70f6e6243a62208071fc148354f3f89cc01b7"},
+    {file = "zope.interface-7.2-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:a102424e28c6b47c67923a1f337ede4a4c2bba3965b01cf707978a801fc7442c"},
+    {file = "zope.interface-7.2-cp311-cp311-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:25e6a61dcb184453bb00eafa733169ab6d903e46f5c2ace4ad275386f9ab327a"},
+    {file = "zope.interface-7.2-cp311-cp311-win_amd64.whl", hash = "sha256:3f6771d1647b1fc543d37640b45c06b34832a943c80d1db214a37c31161a93f1"},
+    {file = "zope.interface-7.2-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:086ee2f51eaef1e4a52bd7d3111a0404081dadae87f84c0ad4ce2649d4f708b7"},
+    {file = "zope.interface-7.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:21328fcc9d5b80768bf051faa35ab98fb979080c18e6f84ab3f27ce703bce465"},
+    {file = "zope.interface-7.2-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f6dd02ec01f4468da0f234da9d9c8545c5412fef80bc590cc51d8dd084138a89"},
+    {file = "zope.interface-7.2-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:8e7da17f53e25d1a3bde5da4601e026adc9e8071f9f6f936d0fe3fe84ace6d54"},
+    {file = "zope.interface-7.2-cp312-cp312-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:cab15ff4832580aa440dc9790b8a6128abd0b88b7ee4dd56abacbc52f212209d"},
+    {file = "zope.interface-7.2-cp312-cp312-win_amd64.whl", hash = "sha256:29caad142a2355ce7cfea48725aa8bcf0067e2b5cc63fcf5cd9f97ad12d6afb5"},
+    {file = "zope.interface-7.2-cp313-cp313-macosx_10_9_x86_64.whl", hash = "sha256:3e0350b51e88658d5ad126c6a57502b19d5f559f6cb0a628e3dc90442b53dd98"},
+    {file = "zope.interface-7.2-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:15398c000c094b8855d7d74f4fdc9e73aa02d4d0d5c775acdef98cdb1119768d"},
+    {file = "zope.interface-7.2-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:802176a9f99bd8cc276dcd3b8512808716492f6f557c11196d42e26c01a69a4c"},
+    {file = "zope.interface-7.2-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:eb23f58a446a7f09db85eda09521a498e109f137b85fb278edb2e34841055398"},
+    {file = "zope.interface-7.2-cp313-cp313-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a71a5b541078d0ebe373a81a3b7e71432c61d12e660f1d67896ca62d9628045b"},
+    {file = "zope.interface-7.2-cp313-cp313-win_amd64.whl", hash = "sha256:4893395d5dd2ba655c38ceb13014fd65667740f09fa5bb01caa1e6284e48c0cd"},
+    {file = "zope.interface-7.2-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:d3a8ffec2a50d8ec470143ea3d15c0c52d73df882eef92de7537e8ce13475e8a"},
+    {file = "zope.interface-7.2-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:31d06db13a30303c08d61d5fb32154be51dfcbdb8438d2374ae27b4e069aac40"},
+    {file = "zope.interface-7.2-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e204937f67b28d2dca73ca936d3039a144a081fc47a07598d44854ea2a106239"},
+    {file = "zope.interface-7.2-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:224b7b0314f919e751f2bca17d15aad00ddbb1eadf1cb0190fa8175edb7ede62"},
+    {file = "zope.interface-7.2-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:baf95683cde5bc7d0e12d8e7588a3eb754d7c4fa714548adcd96bdf90169f021"},
+    {file = "zope.interface-7.2-cp38-cp38-win_amd64.whl", hash = "sha256:7dc5016e0133c1a1ec212fc87a4f7e7e562054549a99c73c8896fa3a9e80cbc7"},
+    {file = "zope.interface-7.2-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:7bd449c306ba006c65799ea7912adbbfed071089461a19091a228998b82b1fdb"},
+    {file = "zope.interface-7.2-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:a19a6cc9c6ce4b1e7e3d319a473cf0ee989cbbe2b39201d7c19e214d2dfb80c7"},
+    {file = "zope.interface-7.2-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:72cd1790b48c16db85d51fbbd12d20949d7339ad84fd971427cf00d990c1f137"},
+    {file = "zope.interface-7.2-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:52e446f9955195440e787596dccd1411f543743c359eeb26e9b2c02b077b0519"},
+    {file = "zope.interface-7.2-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2ad9913fd858274db8dd867012ebe544ef18d218f6f7d1e3c3e6d98000f14b75"},
+    {file = "zope.interface-7.2-cp39-cp39-win_amd64.whl", hash = "sha256:1090c60116b3da3bfdd0c03406e2f14a1ff53e5771aebe33fec1edc0a350175d"},
+    {file = "zope.interface-7.2.tar.gz", hash = "sha256:8b49f1a3d1ee4cdaf5b32d2e738362c7f5e40ac8b46dd7d1a65e82a4872728fe"},
+]
+
+[package.dependencies]
+setuptools = "*"
+
+[package.extras]
+docs = ["Sphinx", "furo", "repoze.sphinx.autointerface"]
+test = ["coverage[toml]", "zope.event", "zope.testing"]
+testing = ["coverage[toml]", "zope.event", "zope.testing"]
+
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.11"
-content-hash = "332b757ce9effa086d425855977e065ded5a83340465b8c6d04ff8e6f63e47d2"
+content-hash = "1c4462a6ff734289e8277ba174fa6ac9e3bc4bbb70803524f4a6d3b22a45736c"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,8 @@ trio = "^0.29.0"
 asgi-lifespan = "^2.1.0"
 pytest-ordering = "^0.6"
 pytest-cov = "^6.0.0"
+pytest-async-sqlalchemy = "^0.2.0"
+gevent = "^24.11.1"
 
 [tool.black]
 line-length = 120
@@ -47,3 +49,7 @@ asyncio_mode = "auto"
 asyncio_default_fixture_loop_scope = "session"
 filterwarnings = "ignore::DeprecationWarning"
 addopts = "--cov=app --cov-report=html --cov-report=xml"
+
+# https://stackoverflow.com/questions/68826941/python-coverage-for-async-methods
+[tool.coverage.run]
+concurrency = ["gevent"]

--- a/tests/test_user.py
+++ b/tests/test_user.py
@@ -1,42 +1,139 @@
 import pytest
+from httpx import AsyncClient
 
 
-@pytest.mark.run(order=1)
-@pytest.mark.asyncio
-async def test_register_first_user(client):
-    # 成功注册用例
-    first_user = {"username": "new_user", "email": "new_user@example.com", "password": "Passw0rd;"}
-    response = await client.post("/api/v1/user/register", json=first_user)
-    print(response.status_code, response.text)
-    assert response.status_code == 200
-    second_user = {"username": "new_user", "email": "new_email@example.com", "password": "Passw0rd;"}
-    response = await client.post("/api/v1/user/register", json=second_user)
-    assert response.status_code == 400
-    thrid_user = {"username": "new_user2", "email": "new_user@example.com", "password": "Passw0rd;"}
-    response = await client.post("/api/v1/user/register", json=thrid_user)
-    assert response.status_code == 400
-
-
-@pytest.mark.run(order=2)
 @pytest.mark.parametrize(
-    "test_user, expected_status",
+    "test_user, expected_status, expected_details",
     [
+        # 成功注册用例
+        ({"username": "new_user", "email": "new_user@example.com", "password": "Passw0rd;"}, 200, ""),
+        ({"username": "new_username", "email": "new_username@example.com", "password": "Passw0rd;"}, 200, ""),
         # 用户名重复
-        ({"username": "new_user", "email": "new_email@example.com", "password": "Passw0rd;"}, 400),
+        ({"username": "new_user", "email": "new_email@example.com", "password": "Passw0rd;"}, 400, "(username)"),
         # 邮箱重复
-        ({"username": "new_user2", "email": "new_user@example.com", "password": "Passw0rd;"}, 400),
+        ({"username": "new_user2", "email": "new_user@example.com", "password": "Passw0rd;"}, 400, "(email)"),
         # 用户名长度不符合要求
-        ({"username": "usr", "email": "invalid_username@example.com", "password": "Passw0rd;"}, 422),
+        ({"username": "usr", "email": "invalid_username@example.com", "password": "Passw0rd;"}, 422, "username"),
         # 密码长度不符合要求
-        ({"username": "new_user3", "email": "new_user3@example.com", "password": "short"}, 422),
+        ({"username": "new_user3", "email": "new_user3@example.com", "password": "short"}, 422, "password"),
         # 密码不符合复杂性要求
-        ({"username": "new_user4", "email": "new_user4@example.com", "password": "NoSpecial123"}, 422),
+        ({"username": "new_user4", "email": "new_user4@example.com", "password": "NoSpecial123"}, 422, "password"),
         # 无效的邮箱格式
-        ({"username": "new_user5", "email": "invalid_email", "password": "Passw0rd;"}, 422),
+        ({"username": "new_user5", "email": "invalid_email", "password": "Passw0rd;"}, 422, "email"),
     ],
 )
-@pytest.mark.asyncio
-async def test_register_user(test_user, expected_status, client):
+# @pytest.mark.asyncio
+async def test_register_user(test_user, expected_status, expected_details, client):
     """测试用户注册的各种情况"""
     response = await client.post("/api/v1/user/register", json=test_user)
     assert response.status_code == expected_status
+    assert expected_details in response.text
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "username, password, expected_status, expected_response",
+    [
+        # ✅ 正确的用户名和密码
+        ("new_user", "Passw0rd;", 200, "access_token"),
+        # ❌ 错误的用户名
+        ("invalid_user", "correct_password", 401, "Incorrect username or password"),
+        # ❌ 错误的密码
+        ("new_user", "wrong_password", 401, "Incorrect username or password"),
+        # ❌ 用户名为空
+        ("", "correct_password", 422, "Username and password is required"),
+        # ❌ 密码为空
+        ("valid_user", "", 422, "Username and password is required"),
+    ],
+)
+async def test_login_for_access_token(username, password, expected_status, expected_response, client: AsyncClient):
+    """
+    测试 `/token` 登录接口的不同情况
+    """
+    # 准备登录请求数据
+    login_data = {"username": username, "password": password}
+    response = await client.post("/api/v1/user/token", data=login_data)
+    assert response.status_code == expected_status
+
+    response_json = response.json()
+    if expected_status == 200:
+        assert "access_token" in response_json
+        assert response_json["token_type"] == "bearer"
+    else:
+        assert expected_response in response_json["detail"]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "current_user, token, expected_status, expected_response",
+    [
+        # ✅ 有效的 JWT 令牌
+        ("new_user", "valid_token", 200, "username"),
+        # ❌ 无效的 JWT 令牌
+        ("new_user", "invalid_token", 401, "Could not validate credentials"),
+        # ❌ 过期的 JWT 令牌
+        ("new_user", "expired_token", 401, "Could not validate credentials"),
+        # ❌ 没有提供 Token
+        ("new_user", None, 401, "Not authenticated"),
+    ],
+)
+async def test_user_me(current_user, token, expected_status, expected_response, generate_token, client: AsyncClient):
+    """
+    测试 `/me` 获取当前用户接口的不同情况
+    """
+    # 生成测试用的 JWT 令牌
+    headers = {}
+    if token:
+        headers = {"Authorization": f"Bearer {generate_token(current_user, token)}"}
+
+    response = await client.get("/api/v1/user/me", headers=headers)
+    assert response.status_code == expected_status
+
+    response_json = response.json()
+    if expected_status == 200:
+        assert "username" in response_json
+    else:
+        assert expected_response in response_json["detail"]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "current_user, token, user_update, expected_status, expected_response",
+    [
+        # ✅ 修改用户名, new_username 也已经存在过了, 所以 400
+        ("new_user", "valid_token", {"username": "new_username"}, 400, "(username)"),  # new_username 也已经存在过了
+        # ✅ 修改用户名, # new_diff_username 也不存在, 所以 200，修改成功
+        ("new_user", "valid_token", {"username": "new_diff_username"}, 200, "new_diff_username"),
+        # ✅ 修改邮箱  email new_email@example.com 也已经存在过了, 所以 400
+        ("new_username", "valid_token", {"email": "new_user@example.com"}, 400, "(email)"),
+        # ✅ 修改邮箱  email new_diff_email@example.com 不存在, 所以 200 , 修改成功
+        ("new_username", "valid_token", {"email": "new_diff_email@example.com"}, 200, "new_diff_email@example.com"),
+        # ✅ 修改密码（不影响返回数据）
+        ("new_username", "valid_token", {"password": "NewPassw0rd!"}, 200, "new_username"),
+        # ❌ 无效 JWT 令牌
+        ("", "invalid_token", {"username": "fail_username"}, 401, "Could not validate credentials"),
+        # ❌ 过期 JWT 令牌
+        ("", "expired_token", {"email": "fail_email@example.com"}, 401, "Could not validate credentials"),
+        # ❌ 无 Token
+        ("", None, {"username": "fail_username"}, 401, "Not authenticated"),
+    ],
+)
+async def test_update_user_me(
+    current_user, token, user_update, expected_status, expected_response, generate_token, client: AsyncClient
+):
+    """
+    测试 `/me` 端点更新用户信息的不同情况
+    """
+    # 生成测试用的 JWT 令牌
+    headers = {}
+    if token:
+        headers = {"Authorization": f"Bearer {generate_token(current_user, token)}"}
+
+    response = await client.put("/api/v1/user/me", headers=headers, json=user_update)
+    assert response.status_code == expected_status
+    response_json = response.json()
+    if expected_status == 200:
+        if "password" not in user_update:
+            assert user_update.get("username", user_update.get("email")) in response_json.values()
+    else:
+        assert expected_response in response_json["detail"]


### PR DESCRIPTION
1. 使用 concurrency = ["gevent"] 解决了测试覆盖率不准确的问题
2. 使用 fixture event_loop(pytest-async-sqlalchemy) 替换 NullPool, 让数据库连接池也能使用
3. 更加充分的单元测试，也基于单元测试对代码进行了调整