### PR TITLE
fix: celery task unregister

### DIFF
--- a/scripts/celery-and-api.sh
+++ b/scripts/celery-and-api.sh
@@ -1,6 +1,6 @@
-nohup celery -A celery_app beat --loglevel=info 2>&1 &
+nohup python3.11 -m celery -A celery_app worker --hostname=worker1 --pool=threads --concurrency=1 --loglevel=info 2>&1 &
+nohup python3.11 -m celery -A celery_app worker --hostname=worker2 --pool=threads --concurrency=1 --loglevel=info 2>&1 &
 
-nohup celery -A celery_app worker --hostname=worker1 --pool=threads --concurrency=1 --loglevel=info 2>&1 &
-nohup celery -A celery_app worker --hostname=worker2 --pool=threads --concurrency=1 --loglevel=info 2>&1 &
+nohup python3.11 -m celery -A celery_app beat --loglevel=info 2>&1 &
 
-uvicorn app.main:app --host 0.0.0.0 --port 8000
+python3.11 -m uvicorn app.main:app --host 0.0.0.0 --port 8000

--- a/scripts/start-celery.sh
+++ b/scripts/start-celery.sh
@@ -12,12 +12,7 @@ set -a
 source .env.local
 set +a
 
-echo "🚀 启动 Celery beat 和 worker ..."
-
-# 启动 Celery Beat
-celery -A celery_app beat --loglevel=info >.log/celery_beat.log 2>&1 &
-echo $! >.pids/celery_beat.pid
-echo "✅ celery_beat 启动，PID: $(cat .pids/celery_beat.pid)"
+echo "🚀 启动 Celery worker 和 beat ..."
 
 # 启动两个 Celery Worker
 for i in 1 2; do
@@ -25,6 +20,11 @@ for i in 1 2; do
   echo $! >".pids/celery_worker_${i}.pid"
   echo "✅ celery_worker_${i} 启动，PID: $(cat .pids/celery_worker_${i}.pid)"
 done
+
+# 启动 Celery Beat
+celery -A celery_app beat --loglevel=info >.log/celery_beat.log 2>&1 &
+echo $! >.pids/celery_beat.pid
+echo "✅ celery_beat 启动，PID: $(cat .pids/celery_beat.pid)"
 
 echo "📡 正在输出日志中（按 Ctrl+C 停止 tail，不会终止 celery）"
 tail -f .log/celery_*.log


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated startup scripts to launch Celery workers before the beat scheduler and to use explicit Python 3.11 module invocation for consistency.
  - Improved script messaging for clarity during service startup.
- **Bug Fixes**
  - Ensured proper loading and registration of task modules for reliable Celery task discovery.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->