### PR TITLE
fix: rename news-summary to api.rss.navydev.top

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ ENV POETRY_VIRTUALENVS_IN_PROJECT=true \
   POETRY_NO_INTERACTION=true
 
 # 设置工作目录
-WORKDIR /news-summary
+WORKDIR /api.rss.navydev.top
 
 # 复制依赖文件（避免代码变动导致重新安装所有依赖）
 COPY pyproject.toml poetry.lock ./
@@ -24,14 +24,14 @@ RUN python3 -m poetry install --only main --no-root
 FROM swr.cn-north-4.myhuaweicloud.com/ddn-k8s/docker.io/python:3.11-slim AS runtime
 
 # 设置虚拟环境路径
-ENV VIRTUAL_ENV=/news-summary/.venv
+ENV VIRTUAL_ENV=/api.rss.navydev.top/.venv
 ENV PATH="$VIRTUAL_ENV/bin:$PATH"
 
 # 设置工作目录
-WORKDIR /news-summary
+WORKDIR /api.rss.navydev.top
 
 # 复制 Poetry 安装的依赖（仅复制已安装的依赖，而不复制 `poetry` 本身）
-COPY --from=builder /news-summary/.venv /news-summary/.venv
+COPY --from=builder /api.rss.navydev.top/.venv /api.rss.navydev.top/.venv
 
 # 复制项目文件
 COPY . .

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
-# 📰 News-Summary
+# 📰 api.rss.navydev.top
 
-![CI](https://github.com/wsgggws/news-summary/actions/workflows/ci.yml/badge.svg)
-[![Codecov](https://codecov.io/gh/wsgggws/news-summary/branch/main/graph/badge.svg)](https://codecov.io/gh/wsgggws/news-summary)
+![CI](https://github.com/wsgggws/api.rss.navydev.top/actions/workflows/ci.yml/badge.svg)
+[![Codecov](https://codecov.io/gh/wsgggws/api.rss.navydev.top/branch/main/graph/badge.svg)](https://codecov.io/gh/wsgggws/api.rss.navydev.top)
 
 **AI 生成个性化新闻摘要**，并在 [Bilibili](https://space.bilibili.com/472722204?spm_id_from=333.1007.0.0) 有合集分享，敬请期待！🚀
 
@@ -9,7 +9,7 @@
 
 - <https://rss.navydev.top/>
 
-[查看页面效果](https://github.com/wsgggws/news-summary-front)
+[查看页面效果](https://github.com/wsgggws/rss.navydev.top)
 
 **注册** 或者使用如下用户密码
 

--- a/app/main.py
+++ b/app/main.py
@@ -48,7 +48,7 @@ setup_middlewares(app)
 
 @app.get("/whoami")
 async def root():
-    return {"whoami": "news-summary"}
+    return {"whoami": "api.rss.navydev.top"}
 
 
 @app.get("/sentry-debug")

--- a/app/middleware_handlers.py
+++ b/app/middleware_handlers.py
@@ -13,7 +13,6 @@ def setup_middlewares(app):
 
     origins = [
         "http://localhost:5173",
-        "https://news-summary-front.onrender.com",
     ]
 
     app.add_middleware(

--- a/app/tracer.py
+++ b/app/tracer.py
@@ -12,7 +12,7 @@ from opentelemetry.sdk.trace.export import (
     ConsoleSpanExporter,  # Optional for debugging
 )
 
-SERVICE_NAME = "news-summary"
+SERVICE_NAME = "api.rss.navydev.top"
 
 
 # Initialize OpenTelemetry Tracer globally

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,8 +7,8 @@ services:
       dockerfile: Dockerfile # 指定 Dockerfile 路径
     container_name: web # 自定义容器名称
     volumes:
-      - .:/news-summary:z # 确保和 Dockerfile 里的 WORKDIR 一致
-      - venv_data:/news-summary/.venv # 避免覆盖 .venv, 开发环境必须要设置
+      - .:/api.rss.navydev.top:z # 确保和 Dockerfile 里的 WORKDIR 一致
+      - venv_data:/api.rss.navydev.top/.venv # 避免覆盖 .venv, 开发环境必须要设置
     ports:
       - "8000:8000" # 暴露 FastAPI 端口
     env_file:
@@ -29,8 +29,8 @@ services:
     container_name: celery-worker
     command: ["sh", "./scripts/start-celery-worker.sh"]
     volumes:
-      - .:/news-summary:z
-      - venv_data:/news-summary/.venv
+      - .:/api.rss.navydev.top:z
+      - venv_data:/api.rss.navydev.top/.venv
     env_file:
       - .env.docker
       - .env
@@ -48,8 +48,8 @@ services:
     container_name: celery-beat
     command: ["sh", "./scripts/start-celery-beat.sh"]
     volumes:
-      - .:/news-summary:z
-      - venv_data:/news-summary/.venv
+      - .:/api.rss.navydev.top:z
+      - venv_data:/api.rss.navydev.top/.venv
     env_file:
       - .env.docker
       - .env

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-name = "news-summary"
+name = "api.rss.navydev.top"
 version = "0.1.0"
 description = ""
 authors = [{ name = "wsgggws", email = "wsgggws@gmail.com" }]
@@ -52,7 +52,7 @@ package-mode = false
 [tool.poetry.group.dev.dependencies]
 pytest = "^8.3.5"
 pytest-asyncio = { extras = ["trio"], version = "^0.25.3" }
-httpx = {extras = ["socks"], version = "^0.28.1"}
+httpx = { extras = ["socks"], version = "^0.28.1" }
 sqlalchemy = "^2.0.39"
 alembic = "^1.15.1"
 trio = "^0.29.0"

--- a/tests/test_whoami.py
+++ b/tests/test_whoami.py
@@ -5,4 +5,4 @@ import pytest
 async def test_whoami(client):
     response = await client.get("/whoami")
     assert response.status_code == 200
-    assert response.json() == {"whoami": "news-summary"}
+    assert response.json() == {"whoami": "api.rss.navydev.top"}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Refactor
  - Rebranded app to “api.rss.navydev.top,” including service identity and /whoami response.
  - Standardized container paths and project root naming across environments.
- Documentation
  - Updated README title, badges, and external links to new branding.
- Chores
  - Adjusted Docker and compose working directories and virtual environment locations.
  - Narrowed CORS allowed origins; removed the previously whitelisted hosted front-end domain.
- Tests
  - Updated tests to reflect the new /whoami response.

No functional changes to APIs beyond the updated identifier and CORS policy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->